### PR TITLE
change table query to use wpdb prepare

### DIFF
--- a/classes/YARPP_Cache_Tables.php
+++ b/classes/YARPP_Cache_Tables.php
@@ -13,7 +13,10 @@ class YARPP_Cache_Tables extends YARPP_Cache {
 	public function is_enabled() {
 		global $wpdb;
 		// now check for the cache table
-		$table_count = $wpdb->get_var("SELECT count(TABLE_NAME) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{$wpdb->dbname}' AND TABLE_NAME = '" . $wpdb->prefix . YARPP_TABLES_RELATED_TABLE . "';");
+		$table_count = $wpdb->get_var($wpdb->prepare(
+			"SELECT count(TABLE_NAME) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'", $wpdb->dbname, ($wpdb->prefix . YARPP_TABLES_RELATED_TABLE)
+			)
+		);
 
 		if ($table_count == 1) 
 			return true;


### PR DESCRIPTION
These are minor changes to the updated code to check for the existence of the yarpp cache table. The goal of these changes is to speed up the original code, which used a SHOW TABLES query and an in_array lookup that performs very poorly with databases with thousands of tables.

I'd originally assembled the query with simple string concatenation to match the style of the other queries in the class, and because the substitution strings are coming directly from the application. However, here it is rewritten with $wpdb->prepare as suggested.

I looked into using "SELECT 1" instead of "SELECT count(TABLE_NAME), but there doesn't seem to be an appreciable speed difference, and I didn't find a straightforward way to get the return value of "SELECT 1" through the existing wp database query methods.