### PR TITLE
Release/4.2.4 bu 0.2

### DIFF
--- a/classes/YARPP_Cache_Tables.php
+++ b/classes/YARPP_Cache_Tables.php
@@ -12,9 +12,10 @@ class YARPP_Cache_Tables extends YARPP_Cache {
 
 	public function is_enabled() {
 		global $wpdb;
-		// now check for the cache tables
-		$tabledata = $wpdb->get_col("show tables");
-		if (in_array($wpdb->prefix . YARPP_TABLES_RELATED_TABLE,$tabledata) !== false)
+		// now check for the cache table
+		$table_count = $wpdb->get_var("SELECT count(TABLE_NAME) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{$wpdb->dbname}' AND TABLE_NAME = '" . $wpdb->prefix . YARPP_TABLES_RELATED_TABLE . "';");
+
+		if ($table_count == 1) 
 			return true;
 		else
 			return false;

--- a/yarpp.php
+++ b/yarpp.php
@@ -2,7 +2,7 @@
 /*----------------------------------------------------------------------------------------------------------------------
 Plugin Name: Yet Another Related Posts Plugin
 Description: Adds related posts to your site and in RSS feeds, based on a powerful, customizable algorithm. Enabling YARPP Pro gives you access to even more powerful features. <a href="http://www.yarpp.com" target="_blank">Find out more</a>.
-Version: 4.2.4
+Version: 4.2.4-BU-0.2
 Author: Adknowledge
 Author URI: http://www.yarpp.com/
 Plugin URI: http://www.yarpp.com/


### PR DESCRIPTION
This request is to release the new optimized database call in the cache table detection code.  The original query ('show tables') had poor performance on a database with thousands of tables.  This branch with the new query was successfully deployed into the test environment and tested against a new clone of the bu.edu/research site, which uses the YARPP plugin, and no problems were seen.