### PR TITLE
Phil/Query caching and optimization

### DIFF
--- a/classes/YARPP_Cache.php
+++ b/classes/YARPP_Cache.php
@@ -463,9 +463,12 @@ abstract class YARPP_Cache {
 		// Sort
 		if ( !isset( $merged_filters[ $tag ] ) ) {
 			//let's stop getting a php warning here, ok?
-			(is_object( $wp_filter[$tag] ) ) ?
-				ksort( get_object_vars( $wp_filter[$tag] ) )
-				: ksort($wp_filter[$tag]);
+			if ( is_object( $wp_filter[ $tag ] ) ) {
+				$tag_filter_vars = get_object_vars( $wp_filter[ $tag ] );
+				ksort( $tag_filter_vars );
+			} else {
+				ksort( $wp_filter[ $tag ] );
+			}
 
 			$merged_filters[ $tag ] = true;
 		}
@@ -477,8 +480,7 @@ abstract class YARPP_Cache {
 
 		do {
 			foreach( (array) current($wp_filter[$tag]) as $the_ )
-				if ( !is_null($the_['function'])
-				and $this->white($the_['function'])){ // HACK
+				if ( isset( $the_['function'] ) && $this->white($the_['function'])){ // HACK
 					$args[1] = $value;
 					$value = call_user_func_array($the_['function'], array_slice($args, 1, (int) $the_['accepted_args']));
 				}

--- a/classes/YARPP_Core.php
+++ b/classes/YARPP_Core.php
@@ -1169,8 +1169,8 @@ class YARPP {
         $output .= ($optin) ? '<img src="http://yarpp.org/pixels/'.md5(get_bloginfo('url')).'" alt="YARPP"/>'."\n" : null;
         $output .= "</div>\n";
 
-		// Cache the output and store it for 15 minutes (900 secs).
-		wp_cache_set( $cache_key, $output, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+		// Cache the output and store it for one day.
+		wp_cache_set( $cache_key, $output, 'bu_yarpp_cache', DAY_IN_SECONDS );
 
         if ($echo) echo $output;
 		return $output;
@@ -1243,8 +1243,8 @@ class YARPP {
 
 		$this->active_cache->end_yarpp_time();
 
-		// Cache the posts and store for 15 minutes (900 secs).
-		wp_cache_set( $cache_key, $related_query->posts, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+		// Cache the posts and store for one day.
+		wp_cache_set( $cache_key, $related_query->posts, 'bu_yarpp_cache', DAY_IN_SECONDS );
 
 		return $related_query->posts;
 	}
@@ -1310,9 +1310,9 @@ class YARPP {
 
 		$return = $related_query->have_posts();
 
-		// Cache the posts and store for 15 minutes (900 secs).
+		// Cache the posts and store for one day.
 		$cached_related_value = ( $return ) ? true : null;
-		wp_cache_set( $cache_key, $cached_related_value, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+		wp_cache_set( $cache_key, $cached_related_value, 'bu_yarpp_cache', DAY_IN_SECONDS );
 
 		unset($related_query);
 

--- a/classes/YARPP_Core.php
+++ b/classes/YARPP_Core.php
@@ -1050,6 +1050,18 @@ class YARPP {
             $reference_ID = get_the_ID();
         }
 
+		// Check for the display_related_for_{$reference_ID} key in the 'bu_yarpp_cache' group.
+		$cached_output = wp_cache_get( "display_related_for_{$reference_ID}", 'bu_yarpp_cache' );
+
+		// If cached output is found, return it and bail.
+		if ( $cached_output ) {
+			if ( $echo ) {
+				echo $cached_output;
+			}
+
+			return $cached_output;
+		}
+
         /**
          * @since 3.5.3 don't compute on revisions.
          */
@@ -1151,6 +1163,9 @@ class YARPP {
         $output .= ($optin) ? '<img src="http://yarpp.org/pixels/'.md5(get_bloginfo('url')).'" alt="YARPP"/>'."\n" : null;
         $output .= "</div>\n";
 
+		// Cache the output and store it for 15 minutes (900 secs).
+		wp_cache_set( "display_related_for_{$reference_ID}", $output, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+
         if ($echo) echo $output;
 		return $output;
 	}
@@ -1170,11 +1185,19 @@ class YARPP {
 			$reference_ID = get_the_ID();
         }
 
+		// Check for the get_related_for_{$reference_ID} key in the 'bu_yarpp_cache' group.
+		$cached_posts = wp_cache_get( "get_related_for_{$reference_ID}", 'bu_yarpp_cache' );
+
+		// If cached posts is found, return them and bail.
+		if ( $cached_posts ) {
+			return $cached_posts;
+		}
+
         /**
 		 * @since 3.5.3: don't compute on revisions.
          */
 		if ($the_post = wp_is_post_revision($reference_ID)) $reference_ID = $the_post;
-			
+
 		$this->setup_active_cache($args);
 
 		$options = array('limit', 'order');
@@ -1207,7 +1230,10 @@ class YARPP {
         );
 	
 		$this->active_cache->end_yarpp_time();
-	
+
+		// Cache the posts and store for 15 minutes (900 secs).
+		wp_cache_set( "get_related_for_{$reference_ID}", $related_query->posts, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+
 		return $related_query->posts;
 	}
 	
@@ -1226,6 +1252,14 @@ class YARPP {
         } else {
 			$reference_ID = get_the_ID();
         }
+
+		// Check for the get_related_for_{$reference_ID} key in the 'bu_yarpp_cache' group.
+		$cached_have_posts = wp_cache_get( "related_exists_for_{$reference_ID}", 'bu_yarpp_cache' );
+
+		// If cached output is found, return it and bail.
+		if ( isset( $cached_have_posts ) ) {
+			return $cached_have_posts;
+		}
 
 		/** @since 3.5.3: don't compute on revisions */
 		if ($the_post = wp_is_post_revision($reference_ID)) $reference_ID = $the_post;
@@ -1259,7 +1293,10 @@ class YARPP {
 		unset($related_query);
 
 		$this->active_cache->end_yarpp_time();
-	
+
+		// Cache the posts and store for 15 minutes (900 secs).
+		wp_cache_set( "related_exists_for_{$reference_ID}", $return, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+
 		return $return;
 	}
 		

--- a/classes/YARPP_Core.php
+++ b/classes/YARPP_Core.php
@@ -1050,8 +1050,11 @@ class YARPP {
             $reference_ID = get_the_ID();
         }
 
-		// Check for the display_related_for_{$reference_ID} key in the 'bu_yarpp_cache' group.
-		$cached_output = wp_cache_get( "display_related_for_{$reference_ID}", 'bu_yarpp_cache' );
+		// Create a cache key from the provided reference ID and args.
+		$cache_key = md5( 'display_related_for_' . wp_json_encode( array( $reference_ID => $args ) ) );
+
+		// Check for the key in the 'bu_yarpp_cache' group.
+		$cached_output = wp_cache_get( $cache_key, 'bu_yarpp_cache' );
 
 		// If cached output is found, return it and bail.
 		if ( $cached_output ) {
@@ -1167,7 +1170,7 @@ class YARPP {
         $output .= "</div>\n";
 
 		// Cache the output and store it for 15 minutes (900 secs).
-		wp_cache_set( "display_related_for_{$reference_ID}", $output, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+		wp_cache_set( $cache_key, $output, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
 
         if ($echo) echo $output;
 		return $output;
@@ -1188,8 +1191,11 @@ class YARPP {
 			$reference_ID = get_the_ID();
         }
 
-		// Check for the get_related_for_{$reference_ID} key in the 'bu_yarpp_cache' group.
-		$cached_posts = wp_cache_get( "get_related_for_{$reference_ID}", 'bu_yarpp_cache' );
+		// Create a cache key from the provided reference ID and args.
+		$cache_key = md5( 'get_related_for_' . wp_json_encode( array( $reference_ID => $args ) ) );
+
+		// Check for the key in the 'bu_yarpp_cache' group.
+		$cached_posts = wp_cache_get( $cache_key, 'bu_yarpp_cache' );
 
 		// If cached posts is found, return them and bail.
 		if ( $cached_posts ) {
@@ -1234,11 +1240,11 @@ class YARPP {
                 'related_ID'    => $reference_ID
             )
         );
-	
+
 		$this->active_cache->end_yarpp_time();
 
 		// Cache the posts and store for 15 minutes (900 secs).
-		wp_cache_set( "get_related_for_{$reference_ID}", $related_query->posts, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+		wp_cache_set( $cache_key, $related_query->posts, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
 
 		return $related_query->posts;
 	}
@@ -1259,8 +1265,11 @@ class YARPP {
 			$reference_ID = get_the_ID();
         }
 
-		// Check for the get_related_for_{$reference_ID} key in the 'bu_yarpp_cache' group.
-		$cached_related = wp_cache_get( "related_exists_for_{$reference_ID}", 'bu_yarpp_cache' );
+		// Create a cache key from the provided reference ID and args.
+		$cache_key = md5( 'related_exists_for_' . wp_json_encode( array( $reference_ID => $args ) ) );
+
+		// Check for the key in the 'bu_yarpp_cache' group.
+		$cached_related = wp_cache_get( $cache_key, 'bu_yarpp_cache' );
 
 		// If cached output is found, return it and bail.
 		if ( isset( $cached_related ) ) {
@@ -1300,10 +1309,10 @@ class YARPP {
         );
 
 		$return = $related_query->have_posts();
-	
+
 		// Cache the posts and store for 15 minutes (900 secs).
 		$cached_related_value = ( $return ) ? true : null;
-		wp_cache_set( "related_exists_for_{$reference_ID}", $cached_related_value, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+		wp_cache_set( $cache_key, $cached_related_value, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
 
 		unset($related_query);
 

--- a/classes/YARPP_Core.php
+++ b/classes/YARPP_Core.php
@@ -1260,11 +1260,11 @@ class YARPP {
         }
 
 		// Check for the get_related_for_{$reference_ID} key in the 'bu_yarpp_cache' group.
-		$cached_have_posts = wp_cache_get( "related_exists_for_{$reference_ID}", 'bu_yarpp_cache' );
+		$cached_related = wp_cache_get( "related_exists_for_{$reference_ID}", 'bu_yarpp_cache' );
 
 		// If cached output is found, return it and bail.
-		if ( isset( $cached_have_posts ) ) {
-			return $cached_have_posts;
+		if ( isset( $cached_related ) ) {
+			return $cached_related;
 		}
 
 		/** @since 3.5.3: don't compute on revisions */
@@ -1298,14 +1298,16 @@ class YARPP {
                 'related_ID'    => $reference_ID
             )
         );
-		
+
 		$return = $related_query->have_posts();
+	
+		// Cache the posts and store for 15 minutes (900 secs).
+		$cached_related_value = ( $return ) ? true : null;
+		wp_cache_set( "related_exists_for_{$reference_ID}", $cached_related_value, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
+
 		unset($related_query);
 
 		$this->active_cache->end_yarpp_time();
-
-		// Cache the posts and store for 15 minutes (900 secs).
-		wp_cache_set( "related_exists_for_{$reference_ID}", $return, 'bu_yarpp_cache', 15 * MINUTE_IN_SECONDS );
 
 		return $return;
 	}

--- a/classes/YARPP_Core.php
+++ b/classes/YARPP_Core.php
@@ -1092,11 +1092,14 @@ class YARPP {
             $orders = explode(' ', $order);
             $wp_query->query(
                 array(
-                    'p'         => $reference_ID,
-                    'orderby'   => $orders[0],
-                    'order'     => $orders[1],
-                    'showposts' => $limit,
-                    'post_type' => (isset($args['post_type']) ? $args['post_type'] : $this->get_post_types())
+                    'p'                      => $reference_ID,
+                    'orderby'                => $orders[0],
+                    'order'                  => $orders[1],
+                    'showposts'              => $limit,
+                    'post_type'              => (isset($args['post_type']) ? $args['post_type'] : $this->get_post_types()),
+                    'no_found_rows'          => true,
+                    'update_post_meta_cache' => false,
+                    'update_post_term_cache' => false,
                 )
             );
         }
@@ -1212,11 +1215,14 @@ class YARPP {
 		$related_query = new WP_Query();
 		$orders = explode(' ',$order);
 		$related_query->query(array(
-			'p'         => $reference_ID,
-			'orderby'   => $orders[0],
-			'order'     => $orders[1],
-			'showposts' => $limit,
-			'post_type' => (isset($args['post_type'])) ? $args['post_type'] : $this->get_post_types()
+			'p'                      => $reference_ID,
+			'orderby'                => $orders[0],
+			'order'                  => $orders[1],
+			'showposts'              => $limit,
+			'post_type'              => (isset($args['post_type'])) ? $args['post_type'] : $this->get_post_types(),
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
 		));
 	
 		$related_query->posts = apply_filters(
@@ -1274,9 +1280,13 @@ class YARPP {
 		$this->active_cache->begin_yarpp_time($reference_ID, $args);
 		$related_query = new WP_Query();
 		$related_query->query(array(
-			'p'         => $reference_ID,
-			'showposts' => 1,
-			'post_type' => (isset($args['post_type'])) ? $args['post_type'] : $this->get_post_types()
+			'p'                      => $reference_ID,
+			'showposts'              => 1,
+			'post_type'              => (isset($args['post_type'])) ? $args['post_type'] : $this->get_post_types(),
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'fields'                 => 'ids',
 		));
 		
 		$related_query->posts = apply_filters(

--- a/includes/template_builtin.php
+++ b/includes/template_builtin.php
@@ -7,8 +7,6 @@
  * More information on the custom templates is available at http://mitcho.com/blog/projects/yarpp-3-templates/
 */
 
-wp_get_current_user();
-
 $options = array(
         'before_title',
         'after_title',

--- a/includes/template_builtin.php
+++ b/includes/template_builtin.php
@@ -7,7 +7,7 @@
  * More information on the custom templates is available at http://mitcho.com/blog/projects/yarpp-3-templates/
 */
 
-get_currentuserinfo();
+wp_get_current_user();
 
 $options = array(
         'before_title',


### PR DESCRIPTION
This caches the queries referenced by the [template tags](https://github.com/bu-ist/yet-another-related-posts-plugin/blob/master/includes/related_functions.php) that the plugin provides. I set the `$expire` parameter for 15 minutes - this could most likely be bumped up.

I'm second guessing myself on the viability/efficiency of this approach, as it sets a cache key for each post individually. Definitely open to feedback and suggestions! I also have some uncommitted work that adds a caching layer to the `$wpdb` invocations in the `classes/YARPP_Cache_...` files. That might just be madness though :), and I'm not certain that it's providing any performance improvement.

Aside from the caching, I added arguments to the queries to help optimize them.

I also made some minor syntax changes based on notices thrown by Query Monitor during testing, and removes the `get_currentuserinfo` call in `includes/template_builtin.php` as it was deprecated in WordPress 4.5 and does not appear to be used anyway.